### PR TITLE
Changed Kivy version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pip install kivymd_extensions.CardStack
 ### Dependencies:
 
 - [KivyMD](https://github.com/kivymd/KivyMD) >= 0.104.1
-- [Kivy](https://github.com/kivy/kivy) >= 1.10.1 ([Installation](https://kivy.org/doc/stable/gettingstarted/installation.html))
+- [Kivy](https://github.com/kivy/kivy) >= 2.0.0 ([Installation](https://kivy.org/doc/stable/gettingstarted/installation.html))
 - [Python 3.6+](https://www.python.org/)
 
 ## Documentation


### PR DESCRIPTION
Changed Kivy version from 1.10.1 to 2.0.0 as KivyMD no longer supports Kivy 1.x.x.